### PR TITLE
READMEにER図と画面遷移図追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 ![スクリーンショット 2022-08-10 15 22 52](https://user-images.githubusercontent.com/81057658/183829977-032e8913-0ca3-4cb3-9548-ccf2c77b1aa0.png)
 
-![スクリーンショット 2022-08-10 15 16 42](https://user-images.githubusercontent.com/81057658/183829192-0d8148cf-e6af-4e18-bfa0-bae64697353a.png)
+![ER図](https://user-images.githubusercontent.com/81057658/184266424-a78c3226-a3cd-45ad-a3dd-527f1ec4d7e8.png)

--- a/README.md
+++ b/README.md
@@ -1,24 +1,5 @@
 # README
 
-This README would normally document whatever steps are necessary to get the
-application up and running.
+[画面遷移図](https://www.figma.com/file/dQr5aXVAyWYFoFQ8jsX1Fx/%E7%A0%94%E4%BF%AE?node-id=0%3A1)
 
-Things you may want to cover:
-
-* Ruby version
-
-* System dependencies
-
-* Configuration
-
-* Database creation
-
-* Database initialization
-
-* How to run the test suite
-
-* Services (job queues, cache servers, search engines, etc.)
-
-* Deployment instructions
-
-* ...
+[ER図]](https://app.diagrams.net/?src=about#G1HgwkGgTyegDilh8vuF_iRsxrVIbTVTds)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # README
 
-[画面遷移図](https://www.figma.com/file/dQr5aXVAyWYFoFQ8jsX1Fx/%E7%A0%94%E4%BF%AE?node-id=0%3A1)
+![スクリーンショット 2022-08-10 15 22 52](https://user-images.githubusercontent.com/81057658/183829977-032e8913-0ca3-4cb3-9548-ccf2c77b1aa0.png)
 
-[ER図](https://app.diagrams.net/?src=about#G1HgwkGgTyegDilh8vuF_iRsxrVIbTVTds)
+![スクリーンショット 2022-08-10 15 16 42](https://user-images.githubusercontent.com/81057658/183829192-0d8148cf-e6af-4e18-bfa0-bae64697353a.png)

--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 [画面遷移図](https://www.figma.com/file/dQr5aXVAyWYFoFQ8jsX1Fx/%E7%A0%94%E4%BF%AE?node-id=0%3A1)
 
-[ER図]](https://app.diagrams.net/?src=about#G1HgwkGgTyegDilh8vuF_iRsxrVIbTVTds)
+[ER図](https://app.diagrams.net/?src=about#G1HgwkGgTyegDilh8vuF_iRsxrVIbTVTds)


### PR DESCRIPTION
ER図と画面遷移図のリンクをREADMEに追加しました。

[画面遷移図](https://www.figma.com/file/dQr5aXVAyWYFoFQ8jsX1Fx/%E7%A0%94%E4%BF%AE?node-id=0%3A1)
[ER図](https://app.diagrams.net/?src=about#G1HgwkGgTyegDilh8vuF_iRsxrVIbTVTds)