### PR TITLE
利用者が登録したタスクだけが一覧ページに表示されるように修正

### DIFF
--- a/app/controllers/graphql_controller.rb
+++ b/app/controllers/graphql_controller.rb
@@ -9,8 +9,7 @@ class GraphqlController < ApplicationController
     query = params[:query]
     operation_name = params[:operationName]
     context = {
-      # Query context goes here, for example:
-      # current_user: current_user,
+      current_user:
     }
     result = MyappSchema.execute(query, variables:, context:, operation_name:)
     render json: result

--- a/app/graphql/mutations/create_task.rb
+++ b/app/graphql/mutations/create_task.rb
@@ -5,8 +5,8 @@ module Mutations
     field :task, ObjectTypes::Task, null: false
 
     def resolve(params:)
-      task = Task.create(params.to_h)
-      { task: } # {"task" :task}の省略形
+      task = context[:current_user].tasks.create(params.to_h)
+      { task: }
     end
   end
 end

--- a/app/graphql/mutations/create_task.rb
+++ b/app/graphql/mutations/create_task.rb
@@ -1,12 +1,16 @@
 module Mutations
-  class CreateTask < Mutations::BaseMutation
+  class CreateTask < LoginRequiredMutation
     argument :params, InputTypes::Task, required: true
 
     field :task, ObjectTypes::Task, null: false
 
     def resolve(params:)
-      task = context[:current_user].tasks.create(params.to_h)
-      { task: }
+      task = context[:current_user].tasks.new(params.to_h)
+      if task.save
+        { task: }
+      else
+        raise GraphQL::ExecutionError, task.errors.full_messages.join("\n")
+      end
     end
   end
 end

--- a/app/graphql/mutations/delete_task.rb
+++ b/app/graphql/mutations/delete_task.rb
@@ -5,7 +5,7 @@ module Mutations
     field :id, ID, null: false
 
     def resolve(id:)
-      Task.find(id).destroy!
+      context[:current_user].tasks.find(id).destroy!
 
       { id: }
     rescue StandardError => e

--- a/app/graphql/mutations/delete_task.rb
+++ b/app/graphql/mutations/delete_task.rb
@@ -1,5 +1,5 @@
 module Mutations
-  class DeleteTask < Mutations::BaseMutation
+  class DeleteTask < LoginRequiredMutation
     argument :id, ID, required: true
 
     field :id, ID, null: false

--- a/app/graphql/mutations/login_required_mutation.rb
+++ b/app/graphql/mutations/login_required_mutation.rb
@@ -1,0 +1,9 @@
+module Mutations
+  class LoginRequiredMutation < BaseMutation
+    def authorized?(_args)
+      raise GraphQL::ExecutionError, 'login required!!' unless context[:current_user]
+
+      true
+    end
+  end
+end

--- a/app/graphql/mutations/update_task.rb
+++ b/app/graphql/mutations/update_task.rb
@@ -6,7 +6,7 @@ module Mutations
     field :task, ObjectTypes::Task, null: false
 
     def resolve(id:, params:)
-      task = Task.find(id)
+      task = context[:current_user].tasks.find(id)
       task.update!(params.to_h)
 
       { task: }

--- a/app/graphql/mutations/update_task.rb
+++ b/app/graphql/mutations/update_task.rb
@@ -1,5 +1,5 @@
 module Mutations
-  class UpdateTask < Mutations::BaseMutation
+  class UpdateTask < LoginRequiredMutation
     argument :id, ID, required: true
     argument :params, InputTypes::Task, required: true
 
@@ -7,11 +7,11 @@ module Mutations
 
     def resolve(id:, params:)
       task = context[:current_user].tasks.find(id)
-      task.update!(params.to_h)
-
-      { task: }
-    rescue StandardError => e
-      GraphQL::ExecutionError.new(e.message)
+      if task.update(params.to_h)
+        { task: }
+      else
+        raise GraphQL::ExecutionError, task.errors.full_messages.join("\n")
+      end
     end
   end
 end

--- a/app/graphql/queries/base_query.rb
+++ b/app/graphql/queries/base_query.rb
@@ -1,4 +1,7 @@
 module Queries
   class BaseQuery < GraphQL::Schema::Resolver
+    def login_required!
+      raise GraphQL::ExecutionError, 'login required!!' unless context[:current_user]
+    end
   end
 end

--- a/app/graphql/queries/task.rb
+++ b/app/graphql/queries/task.rb
@@ -5,6 +5,7 @@ module Queries
     type ObjectTypes::Task, null: false
 
     def resolve(id:)
+      login_required!
       context[:current_user].tasks.find(id)
     end
   end

--- a/app/graphql/queries/task.rb
+++ b/app/graphql/queries/task.rb
@@ -5,7 +5,7 @@ module Queries
     type ObjectTypes::Task, null: false
 
     def resolve(id:)
-      ::Task.find(id)
+      context[:current_user].tasks.find(id)
     end
   end
 end

--- a/app/graphql/queries/tasks.rb
+++ b/app/graphql/queries/tasks.rb
@@ -3,6 +3,7 @@ module Queries
     type [ObjectTypes::Task], null: false
 
     def resolve
+      login_required!
       context[:current_user].tasks.order(created_at: :desc)
     end
   end

--- a/app/graphql/queries/tasks.rb
+++ b/app/graphql/queries/tasks.rb
@@ -3,7 +3,7 @@ module Queries
     type [ObjectTypes::Task], null: false
 
     def resolve
-      ::Task.all.order(created_at: :desc)
+      context[:current_user].tasks.order(created_at: :desc)
     end
   end
 end

--- a/app/javascript/components/FlashMessage.tsx
+++ b/app/javascript/components/FlashMessage.tsx
@@ -11,7 +11,7 @@ const FlashMessage = () => {
     setTimeout(() => {
       navigate(location.pathname, {});
     }, 2000);
-  }, []);
+  }, [locationState]);
 
   return <p>{locationState?.msg}</p>;
 };

--- a/app/javascript/components/InputTask.tsx
+++ b/app/javascript/components/InputTask.tsx
@@ -1,25 +1,31 @@
 import { useCreateTaskMutation } from "../graphql/generated";
 import { useState } from "react";
+import { useNavigate } from "react-router-dom";
 
 const InputTask = () => {
-  const [createTask] = useCreateTaskMutation({ refetchQueries: ["tasks"] });
+  const navigate = useNavigate();
+  const [messages, setMessages] = useState("");
+  const [createTask] = useCreateTaskMutation({
+    refetchQueries: ["tasks"],
+    onError: (e) => {
+      setMessages(e.message);
+      return;
+    },
+    onCompleted: () => {
+      navigate("/", { state: { msg: "タスクが作成されました" } });
+    },
+  });
   const [title, setTitle] = useState("");
   const [body, setBody] = useState("");
-  const [titleVlidateBoolean, setTitleVlidateBoolean] = useState(false);
-  const titleVlidateMessage = "タイトルが未入力です";
-  const titleValidate = () => {
-    if (title === "") {
-      setTitleVlidateBoolean(true);
-    } else {
-      createTask({ variables: { params: { title: title, body: body } } });
-      setTitle("");
-      setBody("");
-    }
+  const onClickCreateTask = () => {
+    createTask({ variables: { params: { title: title, body: body } } });
+    setTitle("");
+    setBody("");
   };
   return (
     <>
+      <p style={{ whiteSpace: "pre-line" }}>{messages}</p>
       <div>
-        <p>{titleVlidateBoolean && titleVlidateMessage}</p>
         <input
           value={title}
           placeholder="タイトルを入力"
@@ -34,7 +40,7 @@ const InputTask = () => {
         />
       </div>
       <div>
-        <button onClick={titleValidate}>保存</button>
+        <button onClick={onClickCreateTask}>保存</button>
       </div>
     </>
   );

--- a/app/javascript/components/TaskShow.tsx
+++ b/app/javascript/components/TaskShow.tsx
@@ -13,7 +13,7 @@ const TaskShow = () => {
     data: { task } = {},
   } = useTaskQuery({ variables: { id: id as string } });
   if (loading) return <p>Loading...</p>;
-  if (error) return <p>`Error! ${error.message}`;</p>;
+  if (error) return <p>Not found</p>;
   if (!task) return <p>Not found</p>;
   return (
     <div>

--- a/app/javascript/components/TaskUpdate.tsx
+++ b/app/javascript/components/TaskUpdate.tsx
@@ -3,35 +3,36 @@ import { useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 
 const TaskUpdate = () => {
+  const [messages, setMessages] = useState("");
   const { id } = useParams();
   const { data: { task } = {} } = useTaskQuery({
     variables: { id: id as string },
   });
 
   const navigate = useNavigate();
-  const updateRedirect = () => navigate(`/tasks/${id}`);
-  const [updateTask] = useUpdateTaskMutation();
+  const [updateTask] = useUpdateTaskMutation({
+    onError: (e) => {
+      setMessages(e.message);
+      return;
+    },
+    onCompleted: () => {
+      navigate(`/tasks/${id}`, { state: { msg: "タスクが更新されました" } });
+    },
+  });
   const [title, setTitle] = useState(task?.title);
   const [body, setBody] = useState(task?.body);
-  const [titleVlidateBoolean, setTitleVlidateBoolean] = useState(false);
-  const titleVlidateMessage = "タイトルが未入力です";
-  const titleValidate = () => {
-    if (title === "") {
-      setTitleVlidateBoolean(true);
-    } else {
-      updateTask({
-        variables: {
-          id: task?.id as string,
-          params: { title: title as string, body: body as string },
-        },
-      });
-      updateRedirect();
-    }
+  const onClickUpdateTask = () => {
+    updateTask({
+      variables: {
+        id: task?.id as string,
+        params: { title: title as string, body: body as string },
+      },
+    });
   };
   return (
     <>
+      <p style={{ whiteSpace: "pre-line" }}>{messages}</p>
       <div>
-        <p>{titleVlidateBoolean && titleVlidateMessage}</p>
         <input value={title} onChange={(e) => setTitle(e.target.value)} />
       </div>
       <div>
@@ -41,7 +42,7 @@ const TaskUpdate = () => {
         />
       </div>
       <div>
-        <button onClick={titleValidate}>更新</button>
+        <button onClick={onClickUpdateTask}>更新</button>
       </div>
     </>
   );

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,4 +1,6 @@
 class Task < ApplicationRecord
   validates :title, presence: true, length: { maximum: 255 }
   validates :body, length: { maximum: 65_535 }
+
+  belongs_to :user
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,4 +4,6 @@ class User < ApplicationRecord
   validates :password, length: { minimum: 3 }, if: -> { new_record? || changes[:crypted_password] }
   validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }
   validates :password_confirmation, presence: true, if: -> { new_record? || changes[:crypted_password] }
+
+  has_many :tasks, dependent: :destroy
 end

--- a/db/migrate/20220912044822_add_user_id_to_tasks.rb
+++ b/db/migrate/20220912044822_add_user_id_to_tasks.rb
@@ -1,0 +1,5 @@
+class AddUserIdToTasks < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :tasks, :user, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 20_220_909_021_238) do
+ActiveRecord::Schema[7.0].define(version: 20_220_912_044_822) do
   # These are extensions that must be enabled in order to support this database
   enable_extension 'plpgsql'
 
@@ -19,6 +19,8 @@ ActiveRecord::Schema[7.0].define(version: 20_220_909_021_238) do
     t.text 'body'
     t.datetime 'created_at', null: false
     t.datetime 'updated_at', null: false
+    t.bigint 'user_id'
+    t.index ['user_id'], name: 'index_tasks_on_user_id'
   end
 
   create_table 'users', force: :cascade do |t|
@@ -30,4 +32,6 @@ ActiveRecord::Schema[7.0].define(version: 20_220_909_021_238) do
     t.datetime 'updated_at', null: false
     t.index ['email'], name: 'index_users_on_email', unique: true
   end
+
+  add_foreign_key 'tasks', 'users'
 end


### PR DESCRIPTION
下記プルリクを先にレビューお願いします。
https://github.com/mofmof/training-miura/pull/18

- TaskモデルとUserモデルを1:多で関連付け
- タスク登録者だけがタスクの閲覧・編集・削除ができるように実装
- 自分が登録していないタスク詳細ページのURLを直接入力すると**Not found**と表示されるように修正

## コミットに対する補足
[エラーメッセージを変更](https://github.com/mofmof/training-miura/pull/21/commits/5d957fb61cc7b2e7b6c79b5a58bb413f79e69796)
自分が登録していないタスク詳細ページのURLを直接入力すると、そのタスクを登録したユーザーのIDが表示されていた。
そのためエラーメッセージを表示せず、**Not found**の文言のみ表示されるように修正

## 確認して欲しいこと
マージされていないプルリクの差分を引き継いで今回のプルリクを作成したが、このやり方で特に問題ないのか確認して欲しいです。