### PR TITLE
編集時にタスクステータスのデフォルト値が入るように修正

### DIFF
--- a/app/graphql/input_types/task.rb
+++ b/app/graphql/input_types/task.rb
@@ -3,8 +3,8 @@ module InputTypes
     graphql_name 'TaskAttributes' # ObjectTypes::Taskと名前がバッティングしないようにする
 
     argument :title, String, required: true
-    argument :body, String, required: true
+    argument :body, String, required: false
     argument :state, Enum::TaskStateEnum, required: true
-    argument :limit_on, String, required: true
+    argument :limit_on, String, required: false
   end
 end

--- a/app/javascript/components/TaskUpdate.tsx
+++ b/app/javascript/components/TaskUpdate.tsx
@@ -31,7 +31,7 @@ const TaskUpdate: FC<Props> = (props) => {
   });
   const [title, setTitle] = useState(task.title);
   const [body, setBody] = useState(task.body);
-  const [limitOn, setLimitOn] = useState(task.limitOn ? task.limitOn : "");
+  const [limitOn, setLimitOn] = useState(task.limitOn);
   const [state, setState] = useState(task.state);
   const onClickUpdateTask = () => {
     updateTask({
@@ -39,8 +39,8 @@ const TaskUpdate: FC<Props> = (props) => {
         id: task.id,
         params: {
           title: title,
-          body: body as string,
-          limitOn: limitOn as string,
+          body: body,
+          limitOn: limitOn,
           state: state,
         },
       },
@@ -54,7 +54,7 @@ const TaskUpdate: FC<Props> = (props) => {
       </div>
       <div>
         <textarea
-          value={body as string}
+          value={body ?? ""}
           onChange={(e) => setBody(e.target.value)}
         />
       </div>
@@ -71,7 +71,7 @@ const TaskUpdate: FC<Props> = (props) => {
           value={TaskState.unstarted}
           name="taskstate"
           defaultChecked={task.state == "unstarted"}
-          onChange={(e) => setState(e.target.value as any)}
+          onChange={(e) => setState(e.target.value as TaskStateEnum)}
         />
         {TaskStateLabel(TaskState.unstarted)}
         <input
@@ -79,7 +79,7 @@ const TaskUpdate: FC<Props> = (props) => {
           value={TaskState.started}
           name="taskstate"
           defaultChecked={task.state == "started"}
-          onChange={(e) => setState(e.target.value as any)}
+          onChange={(e) => setState(e.target.value as TaskStateEnum)}
         />
         {TaskStateLabel(TaskState.started)}
         <input
@@ -87,7 +87,7 @@ const TaskUpdate: FC<Props> = (props) => {
           value={TaskState.finished}
           name="taskstate"
           defaultChecked={task.state == "finished"}
-          onChange={(e) => setState(e.target.value as any)}
+          onChange={(e) => setState(e.target.value as TaskStateEnum)}
         />
         {TaskStateLabel(TaskState.finished)}
       </div>

--- a/app/javascript/components/TaskUpdate.tsx
+++ b/app/javascript/components/TaskUpdate.tsx
@@ -10,7 +10,7 @@ type Props = {
     title: string;
     body?: string | null | undefined;
     state: TaskStateEnum;
-    limitOn?: any;
+    limitOn: string;
   };
 };
 
@@ -30,8 +30,8 @@ const TaskUpdate: FC<Props> = (props) => {
     },
   });
   const [title, setTitle] = useState(task.title);
-  const [body, setBody] = useState(task?.body);
-  const [limitOn, setLimitOn] = useState(task?.limitOn);
+  const [body, setBody] = useState(task.body);
+  const [limitOn, setLimitOn] = useState(task.limitOn ? task.limitOn : "");
   const [state, setState] = useState(task.state);
   const onClickUpdateTask = () => {
     updateTask({
@@ -40,7 +40,7 @@ const TaskUpdate: FC<Props> = (props) => {
         params: {
           title: title,
           body: body as string,
-          limitOn: limitOn,
+          limitOn: limitOn as string,
           state: state,
         },
       },
@@ -70,6 +70,7 @@ const TaskUpdate: FC<Props> = (props) => {
           type="radio"
           value={TaskState.unstarted}
           name="taskstate"
+          defaultChecked={task.state == "unstarted"}
           onChange={(e) => setState(e.target.value as any)}
         />
         {TaskStateLabel(TaskState.unstarted)}
@@ -77,6 +78,7 @@ const TaskUpdate: FC<Props> = (props) => {
           type="radio"
           value={TaskState.started}
           name="taskstate"
+          defaultChecked={task.state == "started"}
           onChange={(e) => setState(e.target.value as any)}
         />
         {TaskStateLabel(TaskState.started)}
@@ -84,6 +86,7 @@ const TaskUpdate: FC<Props> = (props) => {
           type="radio"
           value={TaskState.finished}
           name="taskstate"
+          defaultChecked={task.state == "finished"}
           onChange={(e) => setState(e.target.value as any)}
         />
         {TaskStateLabel(TaskState.finished)}

--- a/app/javascript/graphql/generated.ts
+++ b/app/javascript/graphql/generated.ts
@@ -114,8 +114,8 @@ export type Task = {
 };
 
 export type TaskAttributes = {
-  body: Scalars['String'];
-  limitOn: Scalars['ISO8601Date'];
+  body?: InputMaybe<Scalars['String']>;
+  limitOn?: InputMaybe<Scalars['String']>;
   state: TaskStateEnum;
   title: Scalars['String'];
 };


### PR DESCRIPTION
修正内容
- 編集時にタスクステータスの初期値が入力されていない
登録されているタスクのステータスに対応したラジオボタンがチェックされているように修正
- タスク更新時、期限が未入力の場合にエラーが発生する
登録されているタスク期限が未入力の場合に空の値を渡して登録するように修正