### PR TITLE
利用者はタスクの一覧をステータスで検索できる

### DIFF
--- a/app/graphql/queries/tasks_type.rb
+++ b/app/graphql/queries/tasks_type.rb
@@ -1,10 +1,16 @@
 module Queries
-  class TasksType < Queries::LoginRequiredQuery
+  # class TasksType < Queries::LoginRequiredQuery
+  class TasksType < Queries::BaseQuery
     argument :title, String, required: true
+    argument :state, String, required: false
     type ObjectTypes::Task.connection_type, null: false
 
-    def resolve(title:)
-      context[:current_user].tasks.find_title(title).order(created_at: :desc)
+    def resolve(args)
+      if args[:state].blank?
+        context[:current_user].tasks.find_title(args[:title]).order(created_at: :desc)
+      else
+        context[:current_user].tasks.find_title(args[:title]).where(state: args[:state]).order(created_at: :desc)
+      end
     end
   end
 end

--- a/app/graphql/queries/tasks_type.rb
+++ b/app/graphql/queries/tasks_type.rb
@@ -1,16 +1,13 @@
 module Queries
-  # class TasksType < Queries::LoginRequiredQuery
-  class TasksType < Queries::BaseQuery
+  class TasksType < Queries::LoginRequiredQuery
     argument :title, String, required: true
     argument :state, String, required: false
     type ObjectTypes::Task.connection_type, null: false
 
     def resolve(args)
-      if args[:state].blank?
-        context[:current_user].tasks.find_title(args[:title]).order(created_at: :desc)
-      else
-        context[:current_user].tasks.find_title(args[:title]).where(state: args[:state]).order(created_at: :desc)
-      end
+      tasks = context[:current_user].tasks.find_title(args[:title]).order(created_at: :desc)
+      tasks = tasks.where(state: args[:state]) if args[:state].present?
+      tasks
     end
   end
 end

--- a/app/javascript/components/TaskShow.tsx
+++ b/app/javascript/components/TaskShow.tsx
@@ -1,4 +1,4 @@
-import { useParams, useNavigate } from "react-router-dom";
+import { useParams, useNavigate, Link } from "react-router-dom";
 import { useTaskQuery } from "../graphql/generated";
 import TaskDelete from "./TaskDelete";
 import FlashMessage from "./FlashMessage";
@@ -19,6 +19,7 @@ const TaskShow = () => {
   return (
     <div>
       <FlashMessage />
+      <Link to={"/"}>トップページへ</Link>
       <p>{task.id}</p>
       <p>{task.title}</p>
       <p>{TaskStateLabel(task.state as any)}</p>

--- a/app/javascript/components/TaskUpdate.tsx
+++ b/app/javascript/components/TaskUpdate.tsx
@@ -1,6 +1,6 @@
 import { TaskStateEnum, useUpdateTaskMutation } from "../graphql/generated";
 import { FC, useState } from "react";
-import { useParams, useNavigate } from "react-router-dom";
+import { useParams, useNavigate, Link } from "react-router-dom";
 import { TaskStateLabel, TaskState } from "./Enum";
 
 type Props = {
@@ -49,6 +49,7 @@ const TaskUpdate: FC<Props> = (props) => {
   return (
     <>
       <p style={{ whiteSpace: "pre-line" }}>{messages}</p>
+      <Link to={"/"}>トップページへ</Link>
       <div>
         <input value={title} onChange={(e) => setTitle(e.target.value)} />
       </div>

--- a/app/javascript/components/Tasks.tsx
+++ b/app/javascript/components/Tasks.tsx
@@ -1,16 +1,19 @@
 import { useState } from "react";
 import { Link } from "react-router-dom";
 import { useTasksQuery } from "../graphql/generated";
-import { TaskStateLabel } from "./Enum";
+import { TaskStateLabel, TaskState } from "./Enum";
 
 const Tasks = () => {
-  const [searchInput, setSearchInput] = useState("");
+  const [searchTitle, setSearchTitle] = useState("");
+  const [searchState, setSearchState] = useState("");
   const [title, setTitle] = useState("");
+  const [state, setState] = useState("");
   const { data: { tasks } = {}, fetchMore } = useTasksQuery({
     fetchPolicy: "cache-and-network",
     variables: {
       title: title,
       first: 20,
+      state: state,
     },
   });
   const onClickAddPage = () => {
@@ -23,8 +26,9 @@ const Tasks = () => {
     }
   };
 
-  const taskSearchTitle = () => {
-    if (searchInput) setTitle(searchInput);
+  const taskSearch = () => {
+    if (searchTitle) setTitle(searchTitle);
+    if (searchState) setState(searchState);
   };
 
   const resetTaskSearch = () => setTitle("");
@@ -62,11 +66,26 @@ const Tasks = () => {
     <div>
       <input
         className="bg-gray-50 border border-gray-300 my-3"
-        value={searchInput}
+        value={searchTitle}
         placeholder="タイトルを検索"
-        onChange={(e) => setSearchInput(e.target.value)}
+        onChange={(e) => setSearchTitle(e.target.value)}
       />
-      <button className="bg-gray-300 border" onClick={taskSearchTitle}>
+      <select
+        value={searchState}
+        onChange={(e) => setSearchState(e.target.value)}
+      >
+        <option value="">全て</option>
+        <option value={TaskState.unstarted}>
+          {TaskStateLabel(TaskState.unstarted)}
+        </option>
+        <option value={TaskState.started}>
+          {TaskStateLabel(TaskState.started)}
+        </option>
+        <option value={TaskState.finished}>
+          {TaskStateLabel(TaskState.finished)}
+        </option>
+      </select>
+      <button className="bg-gray-300 border" onClick={taskSearch}>
         検索
       </button>
       <div>

--- a/app/javascript/components/Tasks.tsx
+++ b/app/javascript/components/Tasks.tsx
@@ -7,6 +7,7 @@ const Tasks = () => {
   const [searchInput, setSearchInput] = useState("");
   const [title, setTitle] = useState("");
   const { data: { tasks } = {}, fetchMore } = useTasksQuery({
+    fetchPolicy: "cache-and-network",
     variables: {
       title: title,
       first: 20,

--- a/app/javascript/graphql/generated.ts
+++ b/app/javascript/graphql/generated.ts
@@ -106,6 +106,7 @@ export type QueryTasksArgs = {
   before?: InputMaybe<Scalars['String']>;
   first?: InputMaybe<Scalars['Int']>;
   last?: InputMaybe<Scalars['Int']>;
+  state?: InputMaybe<Scalars['String']>;
   title: Scalars['String'];
 };
 
@@ -241,6 +242,7 @@ export type TaskQuery = { __typename?: 'Query', task: { __typename?: 'Task', id:
 
 export type TasksQueryVariables = Exact<{
   title: Scalars['String'];
+  state?: InputMaybe<Scalars['String']>;
   first?: InputMaybe<Scalars['Int']>;
   after?: InputMaybe<Scalars['String']>;
 }>;
@@ -441,8 +443,8 @@ export type TaskQueryHookResult = ReturnType<typeof useTaskQuery>;
 export type TaskLazyQueryHookResult = ReturnType<typeof useTaskLazyQuery>;
 export type TaskQueryResult = Apollo.QueryResult<TaskQuery, TaskQueryVariables>;
 export const TasksDocument = gql`
-    query tasks($title: String!, $first: Int, $after: String) {
-  tasks(title: $title, first: $first, after: $after) {
+    query tasks($title: String!, $state: String, $first: Int, $after: String) {
+  tasks(title: $title, state: $state, first: $first, after: $after) {
     edges {
       cursor
       node {
@@ -476,6 +478,7 @@ export const TasksDocument = gql`
  * const { data, loading, error } = useTasksQuery({
  *   variables: {
  *      title: // value for 'title'
+ *      state: // value for 'state'
  *      first: // value for 'first'
  *      after: // value for 'after'
  *   },

--- a/app/javascript/graphql/queries/tasks.ts
+++ b/app/javascript/graphql/queries/tasks.ts
@@ -1,8 +1,8 @@
 import { gql } from "@apollo/client";
 
 export default gql`
-  query tasks($title: String!, $first: Int, $after: String) {
-    tasks(title: $title, first: $first, after: $after) {
+  query tasks($title: String!, $state: String, $first: Int, $after: String) {
+    tasks(title: $title, state: $state, first: $first, after: $after) {
       edges {
         cursor
         node {


### PR DESCRIPTION
## 実装概要
- ステータスでのタスク検索機能実装
タイトルとステータスの両方で絞り込み検索ができるように実装した。

## 実装内容詳細
既存のタスク一覧クエリにステータスの引数を持たせるように実装した。
ステータスの引数はrequired falseとした。

参考
特になし

## 気になること
tasks_type.rbファイルのコードはもっと綺麗に書けそうなので相談させて欲しいです。

## その他
[[バグ修正]検索機能が動作しない不具合修正](https://github.com/mofmof/training-miura/pull/38/commits/61247cf0305db54292901d5b9158871a3279c156)
検索機能が動作しない問題について、キャッシュが更新されていないことが原因だった。
キャッシュが更新されるように修正
参考
- https://tech.wasd-inc.com/entry/2020/12/02/222922
- https://qiita.com/tera_shin/items/fa50625103356044f912